### PR TITLE
GoTo dialog: paste cleanup + friendlier validation

### DIFF
--- a/DiztinGUIsh/static/Util.cs
+++ b/DiztinGUIsh/static/Util.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -313,6 +314,32 @@ namespace DiztinGUIsh
                 (data[offset + 1] << 8) |
                 (data[offset + 2] << 16) |
                 (data[offset + 3] << 24);
+        }
+
+        // deal with addresses that look like this,
+        // might be pasted from other editors
+        // C0FFFF
+        // $C0FFFF
+        // C7/AAAA
+        // $C6/BBBB
+        public static bool StripFormattedAddress(ref string addressTxt, NumberStyles style, out int address)
+        {
+            address = -1;
+
+            if (string.IsNullOrEmpty(addressTxt))
+                return false;
+
+            var inputText = new string(Array.FindAll<char>(addressTxt.ToCharArray(), (c => 
+                (char.IsLetterOrDigit(c) || char.IsWhiteSpace(c))
+            )));
+
+            if (int.TryParse(inputText, style, null, out address))
+            {
+                addressTxt = inputText;
+                return true;
+            }
+
+            return false;
         }
 
         public static string TypeToString(Data.FlagType flag)

--- a/DiztinGUIsh/window/MainWindow.cs
+++ b/DiztinGUIsh/window/MainWindow.cs
@@ -615,7 +615,7 @@ namespace DiztinGUIsh
             DialogResult result = go.ShowDialog();
             if (result == DialogResult.OK)
             {
-                int offset = go.GetOffset();
+                int offset = go.GetPcOffset();
                 if (offset >= 0 && offset < Data.GetROMSize()) SelectOffset(offset); 
                 else MessageBox.Show("That offset is out of range.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }

--- a/DiztinGUIsh/window/dialog/GotoDialog.Designer.cs
+++ b/DiztinGUIsh/window/dialog/GotoDialog.Designer.cs
@@ -36,6 +36,7 @@
             this.radioDec = new System.Windows.Forms.RadioButton();
             this.cancel = new System.Windows.Forms.Button();
             this.go = new System.Windows.Forms.Button();
+            this.lblError = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // label1
@@ -59,7 +60,7 @@
             // textROM
             // 
             this.textROM.Location = new System.Drawing.Point(103, 12);
-            this.textROM.MaxLength = 6;
+            this.textROM.MaxLength = 8;
             this.textROM.Name = "textROM";
             this.textROM.Size = new System.Drawing.Size(46, 20);
             this.textROM.TabIndex = 1;
@@ -71,7 +72,7 @@
             // textPC
             // 
             this.textPC.Location = new System.Drawing.Point(103, 38);
-            this.textPC.MaxLength = 6;
+            this.textPC.MaxLength = 8;
             this.textPC.Name = "textPC";
             this.textPC.Size = new System.Drawing.Size(46, 20);
             this.textPC.TabIndex = 3;
@@ -106,7 +107,7 @@
             // cancel
             // 
             this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancel.Location = new System.Drawing.Point(12, 105);
+            this.cancel.Location = new System.Drawing.Point(12, 121);
             this.cancel.Name = "cancel";
             this.cancel.Size = new System.Drawing.Size(75, 23);
             this.cancel.TabIndex = 7;
@@ -117,7 +118,7 @@
             // 
             // go
             // 
-            this.go.Location = new System.Drawing.Point(93, 105);
+            this.go.Location = new System.Drawing.Point(93, 121);
             this.go.Name = "go";
             this.go.Size = new System.Drawing.Size(75, 23);
             this.go.TabIndex = 6;
@@ -125,12 +126,23 @@
             this.go.UseVisualStyleBackColor = true;
             this.go.Click += new System.EventHandler(this.go_Click);
             // 
+            // lblError
+            // 
+            this.lblError.AutoSize = true;
+            this.lblError.ForeColor = System.Drawing.Color.Red;
+            this.lblError.Location = new System.Drawing.Point(12, 102);
+            this.lblError.Name = "lblError";
+            this.lblError.Size = new System.Drawing.Size(39, 13);
+            this.lblError.TabIndex = 8;
+            this.lblError.Text = "lblError";
+            // 
             // GotoDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancel;
-            this.ClientSize = new System.Drawing.Size(180, 140);
+            this.ClientSize = new System.Drawing.Size(180, 153);
+            this.Controls.Add(this.lblError);
             this.Controls.Add(this.go);
             this.Controls.Add(this.cancel);
             this.Controls.Add(this.radioDec);
@@ -161,5 +173,6 @@
         private System.Windows.Forms.RadioButton radioDec;
         private System.Windows.Forms.Button cancel;
         private System.Windows.Forms.Button go;
+        private System.Windows.Forms.Label lblError;
     }
 }

--- a/DiztinGUIsh/window/dialog/GotoDialog.cs
+++ b/DiztinGUIsh/window/dialog/GotoDialog.cs
@@ -26,11 +26,16 @@ namespace DiztinGUIsh
             UpdateUI();
         }
 
-        public int GetOffset()
+        private int ParseOffset(string text)
         {
             NumberStyles style = radioDec.Checked ? NumberStyles.Number : NumberStyles.HexNumber;
-            if (int.TryParse(textPC.Text, style, null, out int offset)) return offset;
+            if (int.TryParse(text, style, null, out int offset)) return offset;
             return -1;
+        }
+
+        public int GetPcOffset()
+        {
+            return ParseOffset(textPC.Text);
         }
 
         private void Go()
@@ -50,7 +55,7 @@ namespace DiztinGUIsh
                 NumberStyles style = radioDec.Checked ? NumberStyles.Number : NumberStyles.HexNumber;
                 Util.NumberBase noBase = radioDec.Checked ? Util.NumberBase.Decimal : Util.NumberBase.Hexadecimal;
 
-                if (Util.StripFormattedAddress(ref txtChanged, style, out var address))
+                if (Util.StripFormattedAddress(ref txtChanged, style, out var address) && address >= 0)
                 {
                     onSuccess(txtChanged, address, noBase);
                     result = true;
@@ -67,35 +72,52 @@ namespace DiztinGUIsh
 
         private void UpdateUI()
         {
-            var validOffset = IsValidOffset();
+            bool valid = true;
+            lblError.Text = "";
 
-            if (validOffset)
+            if (!IsPCOffsetValid())
             {
-                go.Enabled = true;
-                lblError.Text = "";
+                lblError.Text = "Invalid PC Offset";
+                valid = false;
             }
-            else
+
+            if (!IsRomAddressValid())
             {
-                go.Enabled = false;
-                lblError.Text = "Invalid Offset";
+                lblError.Text = "Invalid ROM Address";
+                valid = false;
             }
+
+            go.Enabled = valid;
         }
 
-        private bool IsValidOffset()
+        private bool IsValidPCAddress(int pc)
         {
-            const int highest_offset_allowed = 0xFFFFFF; // TODO: not sure this is correct, probably lower. what's highest address for SNES?
+            return pc >= 0 && pc < Data.GetROMSize();
+        }
 
-            var offset = GetOffset();
-            return offset >= 0 && offset <= highest_offset_allowed;
+        private bool IsPCOffsetValid()
+        {
+            var offset = GetPcOffset();
+            return IsValidPCAddress(offset);
+        }
+
+        private bool IsRomAddressValid()
+        {
+            var address = ParseOffset(textROM.Text);
+            if (address < 0)
+                return false;
+            
+            return IsValidPCAddress(Util.ConvertSNEStoPC(address));
         }
 
         private void textROM_TextChanged(object sender, EventArgs e)
         {
-            UpdateTextChanged(textROM.Text, (finaltext, address, noBase) =>
+            UpdateTextChanged(textROM.Text,(finaltext, address, noBase) =>
             {
                 int pc = Util.ConvertSNEStoPC(address);
-                if (pc >= 0 && pc < Data.GetROMSize()) textPC.Text = Util.NumberToBaseString(pc, noBase, 0);
+                
                 textROM.Text = finaltext;
+                textPC.Text = Util.NumberToBaseString(pc, noBase, 0);
             });
 
             UpdateUI();
@@ -106,8 +128,9 @@ namespace DiztinGUIsh
             UpdateTextChanged(textPC.Text, (finaltext, offset, noBase) =>
             {
                 int addr = Util.ConvertPCtoSNES(offset);
-                if (addr >= 0) textROM.Text = Util.NumberToBaseString(addr, noBase, 6);
+
                 textPC.Text = finaltext;
+                textROM.Text = Util.NumberToBaseString(addr, noBase, 6);
             });
 
             UpdateUI();


### PR DESCRIPTION
(Hi! Love this software. I have a few pull requests coming for changes I made to better suit my workflow from an existing projects. I hope they might be useful for others. Thanks!)

This one is a couple small convenience changes to the GOTO dialog box.

1.  If you paste something into either address box, it will strip down anything that's non-numeric.

This was useful for me pasting in some addresses from a debugger that had were formatted like this:
```$C6/BBBB```

It'll turn that into ```C6BBBB``` without the decoration.


2. Validation message:  I added red text that gives you better hints at what's going wrong if you type in bogus addresses/offsets:

If you're typing in a bogus ROM address:
![image](https://user-images.githubusercontent.com/5413064/91830035-33264780-ec10-11ea-88fd-d7227047a276.png)

or if you're typing in a bogus PC offset:
![image](https://user-images.githubusercontent.com/5413064/91830269-92845780-ec10-11ea-9497-30ac4f56909b.png)


I'm a little shaky on validity of SNES addresses but I think it's covered OK. Please double check my validity checks.