### PR TITLE
Add label-specific comments (comments not tied to any particular address)

### DIFF
--- a/DiztinGUIsh/static/Util.cs
+++ b/DiztinGUIsh/static/Util.cs
@@ -126,7 +126,7 @@ namespace DiztinGUIsh
             }
 
             int pc = ConvertSNEStoPC(ia);
-            if (pc >= 0 && Data.GetLabel(ia) != "") param = Data.GetLabel(ia);
+            if (pc >= 0 && Data.GetLabelName(ia) != "") param = Data.GetLabelName(ia);
             return string.Format(format, param);
         }
 
@@ -258,6 +258,15 @@ namespace DiztinGUIsh
                         return -1;
                     }
             }
+        }
+
+        public static string ReadZipString(byte[] unzipped, ref int pointer)
+        {
+            var label = "";
+            while (unzipped[pointer] != 0)
+                label += (char)unzipped[pointer++];
+            pointer++;
+            return label;
         }
 
         private static int UnmirroredOffset(int offset)

--- a/DiztinGUIsh/static/diz/CPU65C816.cs
+++ b/DiztinGUIsh/static/diz/CPU65C816.cs
@@ -218,7 +218,7 @@ namespace DiztinGUIsh
         {
             int address = Util.GetIntermediateAddress(offset);
             if (address < 0) return "";
-            if (Data.GetLabel(address) != "") return Data.GetLabel(address);
+            if (Data.GetLabelName(address) != "") return Data.GetLabelName(address);
 
             int count = BytesToShow(mode);
             if (mode == AddressMode.RELATIVE_8 || mode == AddressMode.RELATIVE_16) address = Util.GetROMWord(offset + 1);

--- a/DiztinGUIsh/window/AliasList.Designer.cs
+++ b/DiztinGUIsh/window/AliasList.Designer.cs
@@ -31,9 +31,11 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle18 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle16 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle17 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle15 = new System.Windows.Forms.DataGridViewCellStyle();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
             this.Address = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Alias = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Comment = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.import = new System.Windows.Forms.Button();
             this.export = new System.Windows.Forms.Button();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
@@ -54,7 +56,8 @@
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Address,
-            this.Alias});
+            this.Alias,
+            this.Comment});
             dataGridViewCellStyle18.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle18.BackColor = System.Drawing.SystemColors.Window;
             dataGridViewCellStyle18.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -76,7 +79,7 @@
             this.dataGridView1.ShowCellToolTips = false;
             this.dataGridView1.ShowEditingIcon = false;
             this.dataGridView1.ShowRowErrors = false;
-            this.dataGridView1.Size = new System.Drawing.Size(200, 310);
+            this.dataGridView1.Size = new System.Drawing.Size(400, 310);
             this.dataGridView1.TabIndex = 3;
             this.dataGridView1.TabStop = false;
             this.dataGridView1.CellBeginEdit += new System.Windows.Forms.DataGridViewCellCancelEventHandler(this.dataGridView1_CellBeginEdit);
@@ -100,6 +103,15 @@
             this.Alias.MaxInputLength = 20;
             this.Alias.Name = "Alias";
             this.Alias.Width = 138;
+            // 
+            // Comment
+            // 
+            dataGridViewCellStyle15.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Comment.DefaultCellStyle = dataGridViewCellStyle15;
+            this.Comment.HeaderText = "Comment";
+            this.Comment.MaxInputLength = 800;
+            this.Comment.Name = "Comment";
+            this.Comment.Width = 1000;
             // 
             // import
             // 
@@ -126,9 +138,9 @@
             // 
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 339);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 342);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(201, 22);
+            this.statusStrip1.Size = new System.Drawing.Size(402, 22);
             this.statusStrip1.TabIndex = 4;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -160,14 +172,14 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.import;
-            this.ClientSize = new System.Drawing.Size(201, 361);
+            this.ClientSize = new System.Drawing.Size(402, 364);
             this.Controls.Add(this.jump);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.export);
             this.Controls.Add(this.import);
             this.Controls.Add(this.dataGridView1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
-            this.MaximumSize = new System.Drawing.Size(217, 5000);
+            this.MaximumSize = new System.Drawing.Size(600, 5000);
             this.MinimumSize = new System.Drawing.Size(217, 250);
             this.Name = "AliasList";
             this.ShowIcon = false;
@@ -191,6 +203,7 @@
         private System.Windows.Forms.Button export;
         private System.Windows.Forms.DataGridViewTextBoxColumn Address;
         private System.Windows.Forms.DataGridViewTextBoxColumn Alias;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Comment;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
         private System.Windows.Forms.Button jump;

--- a/DiztinGUIsh/window/AliasList.resx
+++ b/DiztinGUIsh/window/AliasList.resx
@@ -123,6 +123,9 @@
   <metadata name="Alias.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="Comment.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/DiztinGUIsh/window/MainWindow.cs
+++ b/DiztinGUIsh/window/MainWindow.cs
@@ -392,7 +392,7 @@ namespace DiztinGUIsh
             if (row >= Data.GetROMSize()) return;
             switch (e.ColumnIndex)
             {
-                case 0: e.Value = Data.GetLabel(Util.ConvertPCtoSNES(row)); break;
+                case 0: e.Value = Data.GetLabelName(Util.ConvertPCtoSNES(row)); break;
                 case 1: e.Value = Util.NumberToBaseString(Util.ConvertPCtoSNES(row), Util.NumberBase.Hexadecimal, 6); break;
                 case 2: e.Value = (char)Data.GetROMByte(row); break;
                 case 3: e.Value = Util.NumberToBaseString(Data.GetROMByte(row), DisplayBase); break;
@@ -424,7 +424,7 @@ namespace DiztinGUIsh
             if (row >= Data.GetROMSize()) return;
             switch (e.ColumnIndex)
             {
-                case 0: Data.AddLabel(Util.ConvertPCtoSNES(row), value, true); break; // todo (validate for valid label characters)
+                case 0: Data.AddLabel(Util.ConvertPCtoSNES(row), new Data.AliasInfo() {name=value}, true); break; // todo (validate for valid label characters)
                 case 8: if (int.TryParse(value, NumberStyles.HexNumber, null, out result)) Data.SetDataBank(row, result); break;
                 case 9: if (int.TryParse(value, NumberStyles.HexNumber, null, out result)) Data.SetDirectPage(row, result); break;
                 case 10: Data.SetMFlag(row, (value == "8" || value == "M")); break;

--- a/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.Designer.cs
@@ -42,13 +42,15 @@
             this.label5 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
             this.numData = new System.Windows.Forms.NumericUpDown();
+            this.chkPrintLabelSpecificComments = new System.Windows.Forms.CheckBox();
+            this.chkIncludeUnusedLabels = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.numData)).BeginInit();
             this.SuspendLayout();
             // 
             // cancel
             // 
             this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancel.Location = new System.Drawing.Point(9, 444);
+            this.cancel.Location = new System.Drawing.Point(9, 491);
             this.cancel.Name = "cancel";
             this.cancel.Size = new System.Drawing.Size(75, 23);
             this.cancel.TabIndex = 12;
@@ -59,7 +61,7 @@
             // 
             // button2
             // 
-            this.button2.Location = new System.Drawing.Point(487, 444);
+            this.button2.Location = new System.Drawing.Point(487, 491);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(113, 23);
             this.button2.TabIndex = 11;
@@ -69,7 +71,7 @@
             // 
             // textFormat
             // 
-            this.textFormat.Location = new System.Drawing.Point(88, 92);
+            this.textFormat.Location = new System.Drawing.Point(88, 139);
             this.textFormat.Name = "textFormat";
             this.textFormat.Size = new System.Drawing.Size(512, 20);
             this.textFormat.TabIndex = 8;
@@ -78,7 +80,7 @@
             // textSample
             // 
             this.textSample.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textSample.Location = new System.Drawing.Point(88, 119);
+            this.textSample.Location = new System.Drawing.Point(88, 166);
             this.textSample.Multiline = true;
             this.textSample.Name = "textSample";
             this.textSample.ReadOnly = true;
@@ -116,7 +118,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 95);
+            this.label1.Location = new System.Drawing.Point(12, 142);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(74, 13);
             this.label1.TabIndex = 7;
@@ -125,7 +127,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(6, 122);
+            this.label2.Location = new System.Drawing.Point(6, 169);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(80, 13);
             this.label2.TabIndex = 9;
@@ -190,12 +192,38 @@
             0});
             this.numData.ValueChanged += new System.EventHandler(this.numData_ValueChanged);
             // 
+            // chkPrintLabelSpecificComments
+            // 
+            this.chkPrintLabelSpecificComments.AutoSize = true;
+            this.chkPrintLabelSpecificComments.Checked = true;
+            this.chkPrintLabelSpecificComments.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkPrintLabelSpecificComments.Location = new System.Drawing.Point(376, 93);
+            this.chkPrintLabelSpecificComments.Name = "chkPrintLabelSpecificComments";
+            this.chkPrintLabelSpecificComments.Size = new System.Drawing.Size(225, 17);
+            this.chkPrintLabelSpecificComments.TabIndex = 13;
+            this.chkPrintLabelSpecificComments.Text = "Print label-specific comments in labels.asm";
+            this.chkPrintLabelSpecificComments.UseVisualStyleBackColor = true;
+            this.chkPrintLabelSpecificComments.CheckedChanged += new System.EventHandler(this.chkPrintLabelSpecificComments_CheckedChanged);
+            // 
+            // chkIncludeUnusedLabels
+            // 
+            this.chkIncludeUnusedLabels.AutoSize = true;
+            this.chkIncludeUnusedLabels.Location = new System.Drawing.Point(376, 115);
+            this.chkIncludeUnusedLabels.Name = "chkIncludeUnusedLabels";
+            this.chkIncludeUnusedLabels.Size = new System.Drawing.Size(192, 17);
+            this.chkIncludeUnusedLabels.TabIndex = 14;
+            this.chkIncludeUnusedLabels.Text = "Include unused labels in labels.asm";
+            this.chkIncludeUnusedLabels.UseVisualStyleBackColor = true;
+            this.chkIncludeUnusedLabels.CheckedChanged += new System.EventHandler(this.chkIncludeUnusedLabels_CheckedChanged);
+            // 
             // ExportDisassembly
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancel;
-            this.ClientSize = new System.Drawing.Size(612, 479);
+            this.ClientSize = new System.Drawing.Size(611, 525);
+            this.Controls.Add(this.chkIncludeUnusedLabels);
+            this.Controls.Add(this.chkPrintLabelSpecificComments);
             this.Controls.Add(this.numData);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.label4);
@@ -235,5 +263,7 @@
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.NumericUpDown numData;
+        private System.Windows.Forms.CheckBox chkPrintLabelSpecificComments;
+        private System.Windows.Forms.CheckBox chkIncludeUnusedLabels;
     }
 }

--- a/DiztinGUIsh/window/dialog/ExportDisassembly.cs
+++ b/DiztinGUIsh/window/dialog/ExportDisassembly.cs
@@ -20,6 +20,8 @@ namespace DiztinGUIsh
             textFormat.Text = LogCreator.format;
             comboUnlabeled.SelectedIndex = (int)LogCreator.unlabeled;
             comboStructure.SelectedIndex = (int)LogCreator.structure;
+            chkIncludeUnusedLabels.Checked = LogCreator.includeUnusedLabels;
+            chkPrintLabelSpecificComments.Checked = LogCreator.printLabelSpecificComments;
             UpdateSample();
         }
 
@@ -98,7 +100,8 @@ namespace DiztinGUIsh
                 List<ROMByte> tempTable = Data.GetTable();
                 Data.ROMMapMode tempMode = Data.GetROMMapMode();
                 Data.ROMSpeed tempSpeed = Data.GetROMSpeed();
-                Dictionary<int, string> tempAlias = Data.GetAllLabels(), tempComment = Data.GetAllComments();
+                var tempAlias = Data.GetAllLabels(); 
+                var tempComment = Data.GetAllComments();
                 LogCreator.FormatStructure tempStructure = LogCreator.structure;
                 Data.Restore(sampleTable, Data.ROMMapMode.LoROM, Data.ROMSpeed.FastROM, sampleAlias, sampleComment);
                 LogCreator.structure = LogCreator.FormatStructure.SingleFile;
@@ -244,14 +247,14 @@ namespace DiztinGUIsh
             new ROMByte {Rom = 0x6D, TypeFlag = Data.FlagType.Data8Bit, DataBank = 0x80, DirectPage = 0x2100},
         };
 
-        public static Dictionary<int, string> sampleAlias = new Dictionary<int, string>
+        public static Dictionary<int, Data.AliasInfo> sampleAlias = new Dictionary<int, Data.AliasInfo>
         {
-            { 0x00, "Emulation_RESET" },
-            { 0x0A, "FastRESET" },
-            { 0x32, "Test_Indices" },
-            { 0x3A, "Pointer_Table" },
-            { 0x44, "First_Routine" },
-            { 0x5B, "Test_Data" }
+            { 0x00, new Data.AliasInfo() {name="Emulation_RESET", comment="Sample emulation reset location"} },
+            { 0x0A, new Data.AliasInfo() {name="FastRESET", comment="Sample label" } },
+            { 0x32, new Data.AliasInfo() {name="Test_Indices"} },
+            { 0x3A, new Data.AliasInfo() {name="Pointer_Table"} },
+            { 0x44, new Data.AliasInfo() {name="First_Routine"} },
+            { 0x5B, new Data.AliasInfo() {name="Test_Data", comment="Pretty cool huh?" } }
         };
 
         public static Dictionary<int, string> sampleComment = new Dictionary<int, string>
@@ -261,5 +264,15 @@ namespace DiztinGUIsh
             { 0x21, "clear APU regs" },
             { 0x44, "this routine copies Test_Data to $7E0100" }
         };
+
+        private void chkPrintLabelSpecificComments_CheckedChanged(object sender, EventArgs e)
+        {
+            LogCreator.printLabelSpecificComments = chkPrintLabelSpecificComments.Checked;
+        }
+
+        private void chkIncludeUnusedLabels_CheckedChanged(object sender, EventArgs e)
+        {
+            LogCreator.includeUnusedLabels = chkIncludeUnusedLabels.Checked;
+        }
     }
 }

--- a/DiztinGUIsh/window/dialog/ImportROMDialog.cs
+++ b/DiztinGUIsh/window/dialog/ImportROMDialog.cs
@@ -43,9 +43,9 @@ namespace DiztinGUIsh
             UpdateOffsetAndSpeed();
         }
 
-        public Dictionary<int, string> GetGeneratedLabels()
+        public Dictionary<int, Data.AliasInfo> GetGeneratedLabels()
         {
-            Dictionary<int, string> labels = new Dictionary<int, string>();
+            var labels = new Dictionary<int, Data.AliasInfo>();
             
             for (int i = 0; i < checkboxes.GetLength(0); i++)
             {
@@ -56,7 +56,8 @@ namespace DiztinGUIsh
                         int index = offset + 15 + 0x10 * i + 2 * j;
                         int val = data[index] + (data[index + 1] << 8);
                         int pc = Util.ConvertSNEStoPC(val);
-                        if (pc >= 0 && pc < data.Length && !labels.ContainsKey(val)) labels.Add(val, vectorNames[i, j]);
+                        if (pc >= 0 && pc < data.Length && !labels.ContainsKey(val)) 
+                            labels.Add(val, new Data.AliasInfo() {name = vectorNames[i, j]}); 
                     }
                 }
             }


### PR DESCRIPTION
I was working in a project where I had created lots of labels by hand for names of subroutines with comments.

I wanted to port these labels over and use DiztinGUIsh to generate the assembly, then generate documentation of ROM and RAM offsets from DiztinGUIsh itself. I also wanted to be able to import other people's address mapping research into a DiztingGUIsh project and have it be the single source of truth for a project and allow exporting to CSVs for publication.

This pull request is a big step in that direction, it allows storing comments specific to a label.

Main stuff:
- store comments specific to labels
  > uses a new AliasInfo class to store information about each label (name and comment)
- add a new checkbox to be able to print these label comments in labels.asm
- add a new checkbox option to print all labels and comments to all-labels.txt for later analysis / documentation
- create a new save file format v2 that can save the comments too
- refactor save file code, combine all versions into one, better deal with multiple versions/backwards compatibility

This PR is good to go, though, the code that prints out all-labels.txt is a little jank. Future work could make the formatting as configurable as the rest of the output.

The refactoring of the load/save functionality ended up being a big chunk of this pull request. If it's too much to chew on, I can probably separate it out into its own PR.

Here's some screenshots, note the new "Comment" column
![image](https://user-images.githubusercontent.com/5413064/91832963-125ff100-ec14-11ea-81ca-b3c9431238c3.png)

2 new options in the asm exporter
![image](https://user-images.githubusercontent.com/5413064/91833349-95814700-ec14-11ea-8e18-58542f3b0509.png)